### PR TITLE
Page navigation update [MAS19YE-32]

### DIFF
--- a/frontend/css/signInPage.css
+++ b/frontend/css/signInPage.css
@@ -1,4 +1,4 @@
-#signin-page {
+#nav-signin-page {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/frontend/css/signUpPage.css
+++ b/frontend/css/signUpPage.css
@@ -1,4 +1,4 @@
-#signup-page {
+#nav-signup-page {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,8 +14,9 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/noty/3.1.4/noty.min.js"></script>   
     <script type="text/javascript" src="js/apiCommunicator.js"></script>
-    <script type="text/javascript" src="js/signInPageController.js"></script>
-    <script type="text/javascript" src="js/signUpPageController.js"></script>
+    <script type="text/javascript" src="js/signInController.js"></script>
+    <script type="text/javascript" src="js/signUpController.js"></script>
+    <script type="text/javascript" src="js/testsController.js"></script>
     <script type="text/javascript" src="js/viewController.js"></script>
     <script type="text/javascript" src="js/index.js"></script>
 </head>
@@ -24,7 +25,7 @@
 
     <div class="content" id="content">
 
-        <div id="signup-page">
+        <div id="nav-signup-page">
             <div class="input-form">
                 <h1>Sign Up</h1>
                 <input id="signup-email-textbox" placeholder="Email" type="email">
@@ -37,7 +38,7 @@
             </div>
         </div>
 
-        <div id="signin-page">
+        <div id="nav-signin-page">
            
             <div class="input-form">
                 <h1>Sign In</h1>
@@ -53,7 +54,7 @@
 
         </div>
 
-        <div id="tests-page">
+        <div id="nav-tests-page">
 
 
 
@@ -62,15 +63,15 @@
 
     <nav>
         <ul>
-            <a id="button-signin">
+            <a id="nav-signin-button">
                 <i class="fas fa-sign-in-alt"></i>
                 Sign in
             </a>
-            <a id="button-signup">
+            <a id="nav-signup-button">
                 <i class="fas fa-user-plus"></i>
                 Sign up
             </a>
-            <a id="button-tests">
+            <a id="nav-tests-button">
                 <i class="fas fa-vials"></i>
                 Tests
             </a>

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -9,7 +9,6 @@ document.addEventListener("DOMContentLoaded", function (ev) {
     apiCommunicator = new ApiCommunicator();
     signInController = new SignInController(apiCommunicator);
     signUpController = new SignUpController(apiCommunicator);
-    signUpController = new SignUpController(apiCommunicator);
     testsController = new TestsController(apiCommunicator);
 
     viewController = new ViewController(

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -3,23 +3,20 @@ let apiCommunicator;
 let viewController;
 let signInController;
 let signUpController;
-let slotsController;
+let testsController;
 
 document.addEventListener("DOMContentLoaded", function (ev) {
     apiCommunicator = new ApiCommunicator();
     signInController = new SignInController(apiCommunicator);
     signUpController = new SignUpController(apiCommunicator);
+    signUpController = new SignUpController(apiCommunicator);
+    testsController = new TestsController(apiCommunicator);
 
     viewController = new ViewController(
         document.getElementById("content"),
         signInController,
-        signUpController);
+        signUpController,
+        testsController);
 
-    viewController.navigateSignIn();
+    viewController.navigate(SignInController);
 });
-
-
-Date.prototype.addHours = function (h) {
-    this.setTime(this.getTime() + (h * 60 * 60 * 1000));
-    return this;
-}

--- a/frontend/js/signInController.js
+++ b/frontend/js/signInController.js
@@ -1,12 +1,14 @@
 class SignInController {
+    static tag = "signin";
+
     constructor(apiCommunicator) {
+        this.tag = SignInController.tag;
         this.apiCommunicator = apiCommunicator;
 
         this.initialized = false;
     }
 
     navigatedTo() {
-
         if (this.initialized)
             return;
 

--- a/frontend/js/signUpController.js
+++ b/frontend/js/signUpController.js
@@ -1,5 +1,8 @@
 class SignUpController {
+    static tag = "signup";
+
     constructor(apiCommunicator) {
+        this.tag = SignUpController.tag;
         this.apiCommunicator = apiCommunicator;
     }
 

--- a/frontend/js/testsController.js
+++ b/frontend/js/testsController.js
@@ -1,0 +1,8 @@
+class TestsController {
+    static tag = "tests";
+
+    constructor(apiCommunicator) {
+        this.tag = TestsController.tag;
+        this.apiCommunicator = apiCommunicator;
+    }
+}

--- a/frontend/js/viewController.js
+++ b/frontend/js/viewController.js
@@ -2,70 +2,52 @@ class ViewController {
     constructor(
         contentContainer,
         signInController,
-        signUpController) {
-            
+        signUpController,
+        testsController) {
         this.contentContainer = contentContainer;
-        this.signInController = signInController;
-        this.signUpController = signUpController;
 
-        this.signUpView = document.getElementById("signup-page");
-        this.signInView = document.getElementById("signin-page");
-        this.testsView = document.getElementById("tests-page");
-
-        this.signInButton = document.getElementById("button-signin");
-        this.signUpButton = document.getElementById("button-signup");
-        this.testsButton = document.getElementById("button-tests");
-
-        this.setUpNavButtons();
+        this.pages = {};
+        this.pages[SignInController.tag] = new Page(this, signInController);
+        this.pages[SignUpController.tag] = new Page(this, signUpController);
+        this.pages[TestsController.tag] = new Page(this, testsController);
 
         while (contentContainer.firstChild) {
             contentContainer.removeChild(contentContainer.firstChild);
         }
     }
 
-    navigateSignIn() {
-        this.setView(this.signInView, this.signInButton);
-        this.signInController.navigatedTo();
-        this.currentController = this.signInController;
+    navigate(pageTag) {
+        let page = this.pages[pageTag.tag];
+
+        this.setView(page);
+        page.controller.navigatedTo();
+        this.currentPage = page;
     }
 
-    navigateSignUp() {
-        this.setView(this.signUpView, this.signUpButton);
-        this.signUpController.navigatedTo();
-        this.currentController = this.signUpController;
-    }
-
-    navigateTests() {
-        this.setView(this.testsView, this.testsButton);
-        this.slotsController.navigatedTo();
-        this.currentController = this.slotsController;
-    }
-
-    setView(view, button) {
+    setView(page) {
         if (this.currentButton)
             this.currentButton.classList.toggle("selected")
 
-        this.currentButton = button;
-        button.classList.toggle("selected");
+        this.currentButton = page.button;
+        this.currentButton.classList.toggle("selected");
 
         if (this.currentChild)
             this.contentContainer.removeChild(this.currentChild);
 
-        this.contentContainer.appendChild(view);
-        this.currentChild = view;
+        this.contentContainer.appendChild(page.view);
+        this.currentChild = page.view;
     }
+}
 
-    setUpNavButtons() {
-        this.signInButton.onclick = () => {
-            this.navigateSignIn();
-        };
+class Page {
+    constructor(viewController, pageController) {
+        this.view = document.getElementById(`nav-${pageController.tag}-page`);
+        this.button = document.getElementById(`nav-${pageController.tag}-button`);
+        this.controller = pageController;
+        this.parent = viewController;
 
-        this.signUpButton.onclick = () => {
-            this.navigateSignUp();
-        };
-
-        this.testsButton.onclick = () => {
-            this.navigateTests();
+        this.button.onclick = () => {
+            this.parent.navigate(pageController);
         };
     }
 }


### PR DESCRIPTION
Allows easier "generic" flow of defining application pages.

This convention assumes pair of HTMLElements with ids `nav-{tag}-page` and `nav-{tag}-button`. Where `button` is the one on the left navigation pane and `page` is the content displayed in the main page.

Each page has its own dedicated controller with defined tag for example:
```js
class SignUpController {
    static tag = "signup";

    constructor(apiCommunicator) {
        this.tag = SignUpController.tag;
```

when registered in `ViewController` one can navigate using `ViewController`'s `navigate()` method. As a parameter you can pass string with tag or for convenience and overall cleanliness you can pass whole controller class which defines the `tag`. For example:
```js
    viewController.navigate(SignInController);
```
